### PR TITLE
Allow the optional use of pod names as string identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We suggest running kube-iptables-tailer as a [Daemonset](https://kubernetes.io/d
 * `PACKET_DROP_EXPIRATION_MINUTES`: (int, default: **10**) Expiration of a packet drop in minutes. Any dropped packet log entries older than this duration will be ignored.
 * `REPEATED_EVENTS_INTERVAL_MINUTES`: (int, default: **2**) Interval of ignoring repeated packet drops in minutes. Any dropped packet log entries with the same source and destination will be ignored if already submitted once within this time period. 
 * `WATCH_LOGS_INTERVAL_SECONDS`: (int, default: **5**) Interval of detecting log changes in seconds. 
-* `POD_IDENTIFIER`: (string, default: **namespace**) How to identify pods in the logs. `pod` or `namespace` are currently supported.
+* `POD_IDENTIFIER`: (string, default: **namespace**) How to identify pods in the logs. `name` or `namespace` are currently supported.
 
 ### Metrics 
 Metrics are implemented by Prometheus, which are hosted on the web server at `/metrics`. The metrics have a name `packet_drops_count` and counter with the following tags:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ We suggest running kube-iptables-tailer as a [Daemonset](https://kubernetes.io/d
 * `PACKET_DROP_EXPIRATION_MINUTES`: (int, default: **10**) Expiration of a packet drop in minutes. Any dropped packet log entries older than this duration will be ignored.
 * `REPEATED_EVENTS_INTERVAL_MINUTES`: (int, default: **2**) Interval of ignoring repeated packet drops in minutes. Any dropped packet log entries with the same source and destination will be ignored if already submitted once within this time period. 
 * `WATCH_LOGS_INTERVAL_SECONDS`: (int, default: **5**) Interval of detecting log changes in seconds. 
+* `POD_IDENTIFIER`: (string, default: **namespace**) How to identify pods in the logs. `pod` or `namespace` are currently supported.
 
 ### Metrics 
 Metrics are implemented by Prometheus, which are hosted on the web server at `/metrics`. The metrics have a name `packet_drops_count` and counter with the following tags:

--- a/event/locator.go
+++ b/event/locator.go
@@ -136,7 +136,7 @@ func getNamespaceOrHostName(pod *v1.Pod, ip string, resolver DnsResolver) string
 			case "namespace":
 				return pod.Namespace
 			}
-			return pod.Name
+			return pod.Namespace
 		}
 		if pod.Spec.NodeName != "" {
 			return pod.Spec.NodeName

--- a/event/locator.go
+++ b/event/locator.go
@@ -120,7 +120,8 @@ func (locator *PodLocator) LocatePod(ip string) (*v1.Pod, error) {
 }
 
 /*
- * 1. If a pod is not using host networking, return its namespace name.
+ * 1. If a pod is not using host networking, return its namespace name, or if the POD_IDENTIFIER
+ *    environment variable is set to 'pod', return the pod name.
  * 2. If a pod is using host networking, return its hostname. This is because multiple pods may
  *    be sharing the host IP, therefore it's impossible to distinguish which pod is the src/dst.
  * 3. If no pod is found, attempt to resolve the IP to hostname.

--- a/event/locator.go
+++ b/event/locator.go
@@ -128,7 +128,14 @@ func (locator *PodLocator) LocatePod(ip string) (*v1.Pod, error) {
 func getNamespaceOrHostName(pod *v1.Pod, ip string, resolver DnsResolver) string {
 	if pod != nil {
 		if !pod.Spec.HostNetwork {
-			return pod.Namespace
+			identifier := util.GetEnvStringOrDefault(util.PodIdentifer, util.DefaultPodIdentifier)
+			switch identifier {
+			case "name":
+				return pod.Name
+			case "namespace":
+				return pod.Namespace
+			}
+			return pod.Name
 		}
 		if pod.Spec.NodeName != "" {
 			return pod.Spec.NodeName

--- a/util/envar.go
+++ b/util/envar.go
@@ -36,6 +36,9 @@ const (
 
 	WatchLogsIntervalSeconds       = "WATCH_LOGS_INTERVAL_SECONDS"
 	DefaultWatchLogsIntervalSecond = 5
+
+	PodIdentifer         = "POD_IDENTIFIER"
+	DefaultPodIdentifier = "namespace"
 )
 
 func GetRequiredEnvString(key string) string {


### PR DESCRIPTION
It's useful for us to have pod to pod metrics about packet drops.