### PR TITLE
Fix ip to pod indexing by only including running pods

### DIFF
--- a/event/locator.go
+++ b/event/locator.go
@@ -59,7 +59,8 @@ type PodLocator struct {
  */
 func NewApiServerPodLocator(client *kubernetes.Clientset) (*PodLocator, error) {
 	listWatch := cache.NewListWatchFromClient(
-		client.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything())
+		client.CoreV1().RESTClient(), "pods", v1.NamespaceAll,
+		fields.AndSelectors(fields.OneTermEqualSelector("status.phase", "Running")))
 
 	return getPodLocator(listWatch), nil
 }


### PR DESCRIPTION
This fixes a bug where completed pods will stay in the index, hogging their old IP, meaning that we register packet drops for running pods incorrectly. We should only index running pods, so new running pods will overwrite the old ones in the index.