### PR TITLE
Ignore non-syn TCP packet drops

### DIFF
--- a/drop/parser.go
+++ b/drop/parser.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-const fieldSrcIP  = "SRC"
-const fieldDstIP  = "DST"
-const fieldProto  = "PROTO"
+const fieldSrcIP = "SRC"
+const fieldDstIP = "DST"
+const fieldProto = "PROTO"
 const fieldTCPSYN = "SYN"
-const protoTCP    = "TCP"
+const protoTCP = "TCP"
 const PacketDropLogTimeLayout = "2006-01-02T15:04:05.000000-07:00"
 
 // PacketDrop is the result object parsed from single raw log containing information about an iptables packet drop.
@@ -112,12 +112,11 @@ func getPacketDrop(packetDropLog string) (PacketDrop, error) {
 	// conntrack. Rules will be applied at a lower precedence which in turn means if we encounter any drops without a
 	// SYN it's because of a broken connection and not a disallowed flow.
 	if protocol, err := getFieldValue(logFields, fieldProto); err == nil && protocol == protoTCP {
-		if _, err = getFieldValue(logFields, fieldTCPSYN); err != nil {
+		if !hasField(logFields, fieldTCPSYN) {
 			// No SYN flag.
 			return PacketDrop{}, errors.New("Ignoring TCP packet without a SYN flag")
 		}
 	}
-
 
 	return PacketDrop{
 			LogTime:  logTime,
@@ -150,4 +149,13 @@ func getFieldValue(logFields []string, fieldName string) (string, error) {
 		}
 	}
 	return "", errors.New(fmt.Sprintf("Missing field=%+v", fieldName))
+}
+
+func hasField(logFields []string, fieldName string) bool {
+	for _, field := range logFields {
+		if field == fieldName || strings.HasPrefix(field, fmt.Sprintf("%s=", fieldName)) {
+			return true
+		}
+	}
+	return false
 }

--- a/drop/parser_test.go
+++ b/drop/parser_test.go
@@ -35,7 +35,7 @@ func TestParsingDropLog(t *testing.T) {
 	channel := make(chan PacketDrop, 100)
 	// need to use curTime because parse() will not insert expired packetDrop
 	curTime := time.Now().Format(PacketDropLogTimeLayout)
-	testLog := fmt.Sprintf("%s %s %s SRC=%s DST=%s", curTime, testHostname, testLogPrefix, testSrcIP, testDstIP)
+	testLog := fmt.Sprintf("%s %s %s SRC=%s DST=%s PROTO=TCP SYN", curTime, testHostname, testLogPrefix, testSrcIP, testDstIP)
 	expected := PacketDrop{
 		LogTime:  curTime,
 		HostName: testHostname,
@@ -93,6 +93,18 @@ func TestParsingNonePacketDropLog(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("Expected error nil, but got error %s", err)
+	}
+}
+
+// Test if packet parser works for none packet drop log (should just ignore and not return error)
+func TestParsingTCPPacketWithoutSYN(t *testing.T) {
+	channel := make(chan PacketDrop)
+	testLog := fmt.Sprintf("%s %s %s SRC=%s DST=%s PROTO=TCP ACK",
+		time.Now().Format(PacketDropLogTimeLayout), testHostname, testLogPrefix, testSrcIP, testDstIP)
+	err := parse(testLogPrefix, testLog, channel)
+
+	if err == nil {
+		t.Fatalf("Expected error, but got error nil!")
 	}
 }
 


### PR DESCRIPTION
As we're not particularly interested in monitoring arbitrary packet drops, just those during TCP session establishment, we purposefully ignore packets that do not include a `SYN` flag.